### PR TITLE
fixed sbt import

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,5 +8,5 @@ scalaVersion := "2.12.3"
 
 // https://mvnrepository.com/artifact/com.typesafe.scala-logging/scala-logging-slf4j_2.11
 //libraryDependencies += "com.typesafe.scala-logging" % "scala-logging-slf4j_2.11" % "2.1.2"
-libraryDependencies += "com.typesafe.scala-logging" % "scala-logging_2.11" % "3.7.2"
+libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2"
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"


### PR DESCRIPTION
Take a look here.

The import, as I wrote on Stackoverflow, should be:

`import com.typesafe.scalalogging.LazyLogging`

Then, the sbt dependency to be added on `build.sbt` instead is:

`"com.typesafe.scala-logging" %% "scala-logging" % "3.7.2"`

Please note the double % sign. It instructs sbt to download the proper dependency binary compatible with the current version of your Scala installation.
